### PR TITLE
Update to 1.5.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.7-slim
+FROM debian:bullseye
 
 LABEL maintainer="https://github.com/alibo"
 
-ARG BOMBSQUAD_VERSION="1.5.22"
+ARG BOMBSQUAD_VERSION="1.5.28"
 
 
-RUN apt-get -y update && apt-get install -y locales libsdl2-2.0-0 wget && rm -rf /var/lib/apt/lists/* \
+RUN apt-get -y update && apt-get install -y python3.8 libpython3.8 locales libsdl2-2.0-0 wget && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-slim
 
 LABEL maintainer="https://github.com/alibo"
 


### PR DESCRIPTION
This updates the BombSquad server to 1.5.28 and replaces python:3.7-slim with debian:bullseye because python:3.7-slim uses Debian Buster which has version 2.28 of libc6 (https://packages.debian.org/buster/libc6) but version 2.29 is required.