### PR TITLE
Update to 1.5.29 and use Ubuntu LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:bullseye-slim
+FROM ubuntu:20.04
 
 LABEL maintainer="https://github.com/alibo"
 
-ARG BOMBSQUAD_VERSION="1.5.28"
+ARG BOMBSQUAD_VERSION="1.5.29"
 
 
 RUN apt-get -y update && apt-get install -y python3.8 libpython3.8 locales libsdl2-2.0-0 wget && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Debian updated python to 3.9 and removed python 3.8 today [1], which breaks the current Dockerfile. BombSquad will keep the version of python in sync with the latest Ubuntu LTS [2], so I propose to use Ubuntu LTS. Ubuntu does not seem to have a slim variant like Debian does, but the image seems to have become smaller: 170MB for Ubuntu LTS and 227MB for bullseye-slim according to `docker ps --size`.

[1] https://tracker.debian.org/news/1209011/python38-removed-from-testing/
[2] https://github.com/efroemling/ballistica/issues/214#issuecomment-743801279